### PR TITLE
Add missing BadgeURL and BadgeName to GetAchievementOfTheWeekAchievement

### DIFF
--- a/event_test.go
+++ b/event_test.go
@@ -88,6 +88,8 @@ func TestGetAchievementOfTheWeek(tt *testing.T) {
 					Points:      5,
 					TrueRatio:   7,
 					Author:      "Scott",
+					BadgeName:   "250341",
+					BadgeURL:    "/Badge/250341.png",
 					DateCreated: &models.DateOnly{
 						Time: dateCreated,
 					},
@@ -128,6 +130,8 @@ func TestGetAchievementOfTheWeek(tt *testing.T) {
 				require.Equal(t, 5, resp.Achievement.Points)
 				require.Equal(t, 7, resp.Achievement.TrueRatio)
 				require.Equal(t, "Scott", resp.Achievement.Author)
+				require.Equal(t, "250341", resp.Achievement.BadgeName)
+				require.Equal(t, "/Badge/250341.png", resp.Achievement.BadgeURL)
 				require.Equal(t, dateCreated, resp.Achievement.DateCreated.Time)
 				require.Equal(t, dateModified, resp.Achievement.DateModified.Time)
 				require.NotNil(t, resp.Achievement.Type)

--- a/models/event.go
+++ b/models/event.go
@@ -21,6 +21,8 @@ type GetAchievementOfTheWeekAchievement struct {
 	Points       int       `json:"Points"`
 	TrueRatio    int       `json:"TrueRatio"`
 	Author       string    `json:"Author"`
+	BadgeName    string    `json:"BadgeName"`
+	BadgeURL     string    `json:"BadgeURL"`
 	DateCreated  *DateOnly `json:"DateCreated"`
 	DateModified *DateOnly `json:"DateModified"`
 	Type         *string   `json:"Type"`


### PR DESCRIPTION
I was implementing a small script to pull achievement of the week information using your library and noticed that it was lacking the fields BadgeName and BadgeURL from the Achievement object. I checked the RA api and it was there so I went ahead and added them.

![image](https://github.com/user-attachments/assets/0cf2a151-29e3-4f26-aeb0-8c73bc3c3f81)
